### PR TITLE
Retry decorator 1

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -24,7 +24,7 @@ jobs:
       - name: dependencias
         run: |
           python -m pip install --upgrade pip
-          pip install requests httpx[http2] asyncio tqdm jsonlines pandas
+          pip install requests httpx[http2] asyncio tqdm jsonlines pandas aiohttp
       - name: correr
         run: |
           python update.py

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -24,7 +24,7 @@ jobs:
       - name: dependencias
         run: |
           python -m pip install --upgrade pip
-          pip install requests httpx[http2] asyncio tqdm jsonlines pandas aiohttp
+          pip install requests httpx[http2] asyncio tqdm jsonlines pandas
       - name: correr
         run: |
           python update.py

--- a/update.py
+++ b/update.py
@@ -8,7 +8,7 @@ import jsonlines
 from datetime import datetime, timezone
 import pandas as pd
 from pathlib import Path
-from utils import async_http_retry
+from utils import async_httpx_retry
 
 
 def listarTramites(pageSize=30):
@@ -37,7 +37,7 @@ def listarTramites(pageSize=30):
     return tramites
 
 
-@async_http_retry(max_retries=5, delay=0.5)
+@async_httpx_retry(max_retries=5, base_delay=0.5)
 async def getTramite(tramite_slug, client):
     """
     Descarga datos de un trámite.

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,43 @@
+"""
+<<<<<<< HEAD
+Utilidades para obtención de trámites.
+=======
+Utilidades adicionales para obtención de trámites.
+>>>>>>> ca536b5 (Decorator para hacer retry al hacer get tramite)
+"""
+
+import asyncio
+import functools
+import aiohttp
+
+
+def async_http_retry(max_retries: int = 3, delay: float = 1.0):
+    """
+    Decorator for async HTTP requests with retry functionality.
+    
+    Args:
+        max_retries: Maximum number of retry attempts
+        delay: Initial delay between retries in seconds (will exponentially increase)
+    """
+    def decorator(func):
+        @functools.wraps(func)
+        async def wrapper(*args, **kwargs):
+            last_exception = None
+            current_delay = delay
+            
+            for attempt in range(max_retries + 1):
+                try:
+                    return await func(*args, **kwargs)
+                except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+                    last_exception = e
+                    if attempt == max_retries:
+                        break
+                    
+                    print(f"Attempt {attempt + 1} failed: {e}. Retrying in {current_delay}s...")
+                    await asyncio.sleep(current_delay)
+                    current_delay *= 2  # Exponential backoff
+            
+            print(f"All {max_retries} retry attempts failed")
+            raise last_exception
+        return wrapper
+    return decorator

--- a/utils.py
+++ b/utils.py
@@ -1,9 +1,5 @@
 """
-<<<<<<< HEAD
-Utilidades para obtención de trámites.
-=======
 Utilidades adicionales para obtención de trámites.
->>>>>>> ca536b5 (Decorator para hacer retry al hacer get tramite)
 """
 
 import asyncio

--- a/utils.py
+++ b/utils.py
@@ -4,7 +4,7 @@ Utilidades adicionales para obtención de trámites.
 
 import asyncio
 import functools
-import aiohttp
+import httpx
 
 
 def async_http_retry(max_retries: int = 3, delay: float = 1.0):
@@ -24,14 +24,13 @@ def async_http_retry(max_retries: int = 3, delay: float = 1.0):
             for attempt in range(max_retries + 1):
                 try:
                     return await func(*args, **kwargs)
-                except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+                except (httpx.HTTPError, httpx.InvalidURL, httpx.StreamError, asyncio.TimeoutError) as e:
                     last_exception = e
                     if attempt == max_retries:
                         break
-                    
                     print(f"Attempt {attempt + 1} failed: {e}. Retrying in {current_delay}s...")
                     await asyncio.sleep(current_delay)
-                    current_delay *= 2  # Exponential backoff
+                    current_delay *= 2 # exponentially backoff
             
             print(f"All {max_retries} retry attempts failed")
             raise last_exception


### PR DESCRIPTION
Agregando un decorator para reducir código en `update.py`
```
@async_http_retry(max_retries=5, delay=0.5)
async def getTramite(tramite_slug, client):
```
Permite también ser reutilizado en otras funciones en caso de ser necesario a futuro.