### PR TITLE
fix detectarAdiciones

### DIFF
--- a/update.py
+++ b/update.py
@@ -186,6 +186,7 @@ def detectarAdiciones(df1, df2, timestamp):
     # El formato de la bitácora
     def formatear(df, evento, timestamp):
         n = df[["id", "entidad", "nombre"]].copy()
+        n["entidad"] = n["entidad"].str["nombre"]
         n.columns = ["id", "entidad", "nombre"]
         n.insert(0, "tipo", evento)
         n.insert(0, "timestamp", timestamp)


### PR DESCRIPTION
Addendum rápido al anterior PR #6 . Sin este cambio los valores futuros en la columna `entidad` de `adiciones.csv` serían los objetos completos de `entidad` que reporta gob bo. Este PR simple permite preservar la estructura que ya tenemos en `adiciones.csv`.